### PR TITLE
Handle KeyboardInterrupt gracefully

### DIFF
--- a/MyNano.py
+++ b/MyNano.py
@@ -314,4 +314,7 @@ def main(stdscr, filename=None):
 
 if __name__ == "__main__":
     filename = sys.argv[1] if len(sys.argv) > 1 else None
-    curses.wrapper(main, filename)
+    try:
+        curses.wrapper(main, filename)
+    except KeyboardInterrupt:
+        print("\nExiting...")


### PR DESCRIPTION
## Summary
- wrap the curses wrapper in a try/except block
- print a short message if the user aborts via `Ctrl+C`

## Testing
- `python3 -m py_compile MyNano.py`

------
https://chatgpt.com/codex/tasks/task_e_68544f0e1d148320b73d416038548674